### PR TITLE
Mach/imgui fixes

### DIFF
--- a/src/deps/zig-gamedev/zgui/src/zgui_mach.zig
+++ b/src/deps/zig-gamedev/zgui/src/zgui_mach.zig
@@ -88,11 +88,11 @@ pub fn MachBackend(comptime mach: anytype) type {
             ImGui_ImplWGPU_RenderDrawData(zgui.getDrawData(), wgpu_render_pass);
         }
 
-        pub fn passEvent(event: mach.Core.Event) void {
+        pub fn passEvent(event: mach.Core.Event, content_scale: [2]f32) void {
             switch (event) {
                 .mouse_motion => {
                     const pos = event.mouse_motion.pos;
-                    ImGui_ImplMach_CursorPosCallback(pos.x, pos.y);
+                    ImGui_ImplMach_CursorPosCallback(pos.x*content_scale[0], pos.y*content_scale[1]);
                 },
                 .mouse_press => {
                     ImGui_ImplMach_MouseButtonCallback(0, 1, 0);

--- a/src/deps/zig-gamedev/zgui/src/zgui_mach.zig
+++ b/src/deps/zig-gamedev/zgui/src/zgui_mach.zig
@@ -7,6 +7,10 @@ pub const c = @cImport({
 
 pub fn MachBackend(comptime mach: anytype) type {
     return struct {
+        var core: *mach.Core = undefined;
+        var last_width: u32 = 0;
+        var last_height: u32 = 0;
+
         const TextureFormat = mach.gpu.Texture.Format;
         pub fn machKeyToImgui(key: mach.Core.Key) u32 {
             return switch (key) {
@@ -55,13 +59,11 @@ pub fn MachBackend(comptime mach: anytype) type {
             };
         }
 
-        pub fn init(core: *mach.Core, wgpu_device: *const anyopaque, rt_format: TextureFormat, cfg: Config) void {
+        pub fn init(core2: *mach.Core, wgpu_device: *const anyopaque, rt_format: TextureFormat, cfg: Config) void {
             if (!ImGui_ImplWGPU_Init(wgpu_device, 1, @intFromEnum(rt_format), &cfg)) {
                 unreachable;
             }
-
-            const size = core.size();
-            zgui.io.setDisplaySize(@as(f32, @floatFromInt(size.width)), @as(f32, @floatFromInt(size.height)));
+            core = core2;
         }
 
         pub fn deinit() void {
@@ -69,6 +71,13 @@ pub fn MachBackend(comptime mach: anytype) type {
         }
 
         pub fn newFrame() void {
+            const desc = core.descriptor();
+            if (desc.width != last_width or desc.height != last_height) {
+                last_width = desc.width;
+                last_height = desc.height;
+                zgui.io.setDisplaySize(@as(f32, @floatFromInt(desc.width)), @as(f32, @floatFromInt(desc.height)));
+            }
+
             ImGui_ImplWGPU_NewFrame();
 
             zgui.newFrame();
@@ -107,9 +116,6 @@ pub fn MachBackend(comptime mach: anytype) type {
                 },
                 .char_input => {
                     ImGui_ImplMach_CharCallback(event.char_input.codepoint);
-                },
-                .framebuffer_resize => |ev| {
-                    zgui.io.setDisplaySize(@as(f32, @floatFromInt(ev.width)), @as(f32, @floatFromInt(ev.height)));
                 },
                 else => {},
             }

--- a/src/editor/artboard/artboard.zig
+++ b/src/editor/artboard/artboard.zig
@@ -24,8 +24,8 @@ pub fn draw() void {
         .cond = .always,
     });
     zgui.setNextWindowSize(.{
-        .w = (zgui.getWindowSize()[0] - pixi.state.settings.explorer_width - pixi.state.settings.sidebar_width) * pixi.content_scale[0],
-        .h = zgui.getWindowSize()[1] * pixi.content_scale[1] + 5.0,
+        .w = ((zgui.getWindowSize()[0]*pixi.content_scale[0]) - pixi.state.settings.explorer_width - pixi.state.settings.sidebar_width) * pixi.content_scale[0],
+        .h = (zgui.getWindowSize()[1]*pixi.content_scale[1]) * pixi.content_scale[1] + 5.0,
     });
 
     zgui.pushStyleVar2f(.{ .idx = zgui.StyleVar.window_padding, .v = .{ 0.0, 0.0 } });

--- a/src/editor/explorer/animations.zig
+++ b/src/editor/explorer/animations.zig
@@ -26,7 +26,9 @@ pub fn draw() void {
             defer zgui.endChild();
 
             const style = zgui.getStyle();
-            const window_size = zgui.getWindowSize();
+            var window_size = zgui.getWindowSize();
+            window_size[0] *= pixi.content_scale[0];
+            window_size[1] *= pixi.content_scale[1];
 
             const button_width = window_size[0] / 4.0;
             const button_height = button_width / 2.0;

--- a/src/editor/explorer/explorer.zig
+++ b/src/editor/explorer/explorer.zig
@@ -23,8 +23,9 @@ pub fn draw() void {
         .cond = .always,
     });
     zgui.setNextWindowSize(.{
+        // SLIMSAG
         .w = pixi.state.settings.explorer_width * pixi.content_scale[0],
-        .h = zgui.getWindowSize()[1] * pixi.content_scale[1],
+        .h = zgui.getWindowSize()[1] * pixi.content_scale[1] * pixi.content_scale[1],
     });
 
     if (zgui.begin("Explorer", .{

--- a/src/editor/explorer/tools.zig
+++ b/src/editor/explorer/tools.zig
@@ -16,7 +16,9 @@ pub fn draw() void {
         defer zgui.endChild();
 
         const style = zgui.getStyle();
-        const window_size = zgui.getWindowSize();
+        var window_size = zgui.getWindowSize();
+        window_size[0] *= pixi.content_scale[0];
+        window_size[1] *= pixi.content_scale[1];
 
         const button_width = window_size[0] / 4.0;
         const button_height = button_width / 2.0;

--- a/src/editor/popups/about.zig
+++ b/src/editor/popups/about.zig
@@ -11,7 +11,9 @@ pub fn draw() void {
     const popup_width = 450 * pixi.content_scale[0];
     const popup_height = 450 * pixi.content_scale[1];
 
-    const window_size = zgui.getWindowSize();
+    var window_size = zgui.getWindowSize();
+    window_size[0] *= pixi.content_scale[0];
+    window_size[1] *= pixi.content_scale[1];
     const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
     zgui.setNextWindowPos(.{

--- a/src/editor/popups/animation.zig
+++ b/src/editor/popups/animation.zig
@@ -20,7 +20,9 @@ pub fn draw() void {
         const popup_width = 350 * pixi.content_scale[0];
         const popup_height = 115 * pixi.content_scale[1];
 
-        const window_size = zgui.getWindowSize();
+        var window_size = zgui.getWindowSize();
+        window_size[0] *= pixi.content_scale[0];
+        window_size[1] *= pixi.content_scale[1];
         const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
         zgui.setNextWindowPos(.{

--- a/src/editor/popups/color.zig
+++ b/src/editor/popups/color.zig
@@ -10,7 +10,7 @@ pub fn draw() void {
     const popup_width = 450 * pixi.content_scale[0];
     const popup_height = 450 * pixi.content_scale[1];
 
-    const window_size = zgui.getWindowSize() * pixi.content_scale;
+    const window_size = zgui.getWindowSize() * pixi.content_scale * pixi.content_scale;
     const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
     zgui.setNextWindowPos(.{

--- a/src/editor/popups/export_png.zig
+++ b/src/editor/popups/export_png.zig
@@ -13,7 +13,9 @@ pub fn draw() void {
     const popup_width = 350 * pixi.content_scale[0];
     const popup_height = 300 * pixi.content_scale[1];
 
-    const window_size = zgui.getWindowSize();
+    var window_size = zgui.getWindowSize();
+    window_size[0] *= pixi.content_scale[0];
+    window_size[1] *= pixi.content_scale[1];
     const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
     zgui.setNextWindowPos(.{

--- a/src/editor/popups/file_confirm_close.zig
+++ b/src/editor/popups/file_confirm_close.zig
@@ -11,7 +11,9 @@ pub fn draw() void {
     const popup_width = 350 * pixi.content_scale[0];
     const popup_height = if (pixi.state.popups.file_confirm_close_state == .one) 120 * pixi.content_scale[1] else 250 * pixi.content_scale[1];
 
-    const window_size = zgui.getWindowSize();
+    var window_size = zgui.getWindowSize();
+    window_size[0] *= pixi.content_scale[0];
+    window_size[1] *= pixi.content_scale[1];
     const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
     zgui.setNextWindowPos(.{

--- a/src/editor/popups/file_setup.zig
+++ b/src/editor/popups/file_setup.zig
@@ -11,7 +11,9 @@ pub fn draw() void {
     const popup_width = 350 * pixi.content_scale[0];
     const popup_height = 300 * pixi.content_scale[1];
 
-    const window_size = zgui.getWindowSize();
+    var window_size = zgui.getWindowSize();
+    window_size[0] *= pixi.content_scale[0];
+    window_size[1] *= pixi.content_scale[1];
     const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
     zgui.setNextWindowPos(.{

--- a/src/editor/popups/heightmap.zig
+++ b/src/editor/popups/heightmap.zig
@@ -12,7 +12,9 @@ pub fn draw() void {
         const popup_width = 350 * pixi.content_scale[0];
         const popup_height = 115 * pixi.content_scale[1];
 
-        const window_size = zgui.getWindowSize();
+        var window_size = zgui.getWindowSize();
+        window_size[0] *= pixi.content_scale[0];
+        window_size[1] *= pixi.content_scale[1];
         const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
         zgui.setNextWindowPos(.{

--- a/src/editor/popups/layer_setup.zig
+++ b/src/editor/popups/layer_setup.zig
@@ -18,7 +18,9 @@ pub fn draw() void {
         const popup_width = 350 * pixi.content_scale[0];
         const popup_height = 115 * pixi.content_scale[1];
 
-        const window_size = zgui.getWindowSize();
+        var window_size = zgui.getWindowSize();
+        window_size[0] *= pixi.content_scale[0];
+        window_size[1] *= pixi.content_scale[1];
         const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
         zgui.setNextWindowPos(.{

--- a/src/editor/popups/rename.zig
+++ b/src/editor/popups/rename.zig
@@ -17,7 +17,9 @@ pub fn draw() void {
     const popup_width = 350 * pixi.content_scale[0];
     const popup_height = 115 * pixi.content_scale[1];
 
-    const window_size = zgui.getWindowSize();
+    var window_size = zgui.getWindowSize();
+    window_size[0] *= pixi.content_scale[0];
+    window_size[1] *= pixi.content_scale[1];
     const window_center: [2]f32 = .{ window_size[0] / 2.0, window_size[1] / 2.0 };
 
     zgui.setNextWindowPos(.{

--- a/src/editor/sidebar/sidebar.zig
+++ b/src/editor/sidebar/sidebar.zig
@@ -12,7 +12,8 @@ pub fn draw() void {
     });
     zgui.setNextWindowSize(.{
         .w = pixi.state.settings.sidebar_width * pixi.content_scale[0],
-        .h = zgui.getWindowSize()[1] * pixi.content_scale[1],
+        // SLIMSAG
+        .h = zgui.getWindowSize()[1] * pixi.content_scale[1] * pixi.content_scale[1],
     });
     zgui.pushStyleVar2f(.{ .idx = zgui.StyleVar.selectable_text_align, .v = .{ 0.5, 0.5 } });
     zgui.pushStyleColor4f(.{ .idx = zgui.StyleCol.header, .c = pixi.state.style.foreground.toSlice() });

--- a/src/gfx/camera.zig
+++ b/src/gfx/camera.zig
@@ -15,6 +15,8 @@ pub const Camera = struct {
 
     pub fn matrix(self: Camera) Matrix3x2 {
         var window_size = zgui.getWindowSize();
+        window_size[0] *= pixi.content_scale[0];
+        window_size[1] *= pixi.content_scale[1];
         var window_half_size: [2]f32 = .{ @trunc(window_size[0] * 0.5), @trunc(window_size[1] * 0.5) };
 
         var transform = Matrix3x2.identity;

--- a/src/pixi.zig
+++ b/src/pixi.zig
@@ -284,7 +284,7 @@ pub fn update(app: *App) !bool {
             .close => return true,
             else => {},
         }
-        zgui.mach_backend.passEvent(event);
+        zgui.mach_backend.passEvent(event, content_scale);
     }
 
     input.process() catch unreachable;

--- a/src/pixi.zig
+++ b/src/pixi.zig
@@ -197,8 +197,10 @@ pub fn init(app: *App) !void {
     const descriptor = app.core.descriptor();
     const window_size = app.core.size();
     content_scale = .{
-        @floatFromInt(descriptor.width / window_size.width),
-        @floatFromInt(descriptor.height / window_size.height),
+        // type inference doesn't like this, but the important part is to make sure we're dividing
+        // as floats not integers.
+        @as(f32, @floatFromInt(descriptor.width)) / @as(f32, @floatFromInt(window_size.width)),
+        @as(f32, @floatFromInt(descriptor.height)) / @as(f32, @floatFromInt(window_size.height)),
     };
 
     const scale_factor = content_scale[1];


### PR DESCRIPTION
The first three commits I feel really good about; they are reflecting what is done in zgui upstream proper - which is what your application also expects and the experience you got with zgui before. It also fixes a crash-on-resize bug that existed before.

The fourth commit _seemed_ to help make the sizes of things more correct with respect to what the `main` branch shows when I run that - I think that `zgui.getWindowSize()` reports _the framebuffer size_ (e.g. 1280px instead of 640 virtual px) - but I'm fuzzy on the details here and suspect something is still wrong with these calculations because I couldn't get it to match 1:1 with what the `main` branch shows. It could be due to the actual window size being different? I just noticed that when taking these screenshots:

With this branch:

<img width="1072" alt="image" src="https://github.com/foxnne/pixi/assets/3173176/19bff40a-9411-4050-95c2-c8ff22c4938f">

With the `main` branch:

<img width="1392" alt="image" src="https://github.com/foxnne/pixi/assets/3173176/2cf49796-a864-4079-81a9-07dd902d7f91">
