### PR TITLE
update @fabs to @abs and fix one type error

### DIFF
--- a/src/algorithms/brezenham.zig
+++ b/src/algorithms/brezenham.zig
@@ -9,7 +9,7 @@ pub fn process(start: [2]f32, end: [2]f32) ![][2]f32 {
     var x2 = end[0];
     var y2 = end[1];
 
-    const steep = @fabs(y2 - y1) > @fabs(x2 - x1);
+    const steep = @abs(y2 - y1) > @abs(x2 - x1);
     if (steep) {
         std.mem.swap(f32, &x1, &y1);
         std.mem.swap(f32, &x2, &y2);
@@ -21,7 +21,7 @@ pub fn process(start: [2]f32, end: [2]f32) ![][2]f32 {
     }
 
     const dx: f32 = x2 - x1;
-    const dy: f32 = @fabs(y2 - y1);
+    const dy: f32 = @abs(y2 - y1);
 
     var err: f32 = dx / 2.0;
     var ystep: i32 = if (y1 < y2) 1 else -1;

--- a/src/deps/zig-gamedev/zmath/src/zmath.zig
+++ b/src/deps/zig-gamedev/zmath/src/zmath.zig
@@ -1346,7 +1346,7 @@ pub inline fn sqrt(v: anytype) @TypeOf(v) {
 }
 
 pub inline fn abs(v: anytype) @TypeOf(v) {
-    return @fabs(v); // load, andps
+    return @abs(v); // load, andps
 }
 
 pub inline fn select(mask: anytype, v0: anytype, v1: anytype) @TypeOf(v0, v1) {
@@ -3612,7 +3612,7 @@ test "zmath.sincos32" {
 }
 
 fn asin32(v: f32) f32 {
-    const x = @fabs(v);
+    const x = @abs(v);
     var omx = 1.0 - x;
     if (omx < 0.0) {
         omx = 0.0;
@@ -3666,7 +3666,7 @@ test "zmath.asin32" {
 }
 
 fn acos32(v: f32) f32 {
-    const x = @fabs(v);
+    const x = @abs(v);
     var omx = 1.0 - x;
     if (omx < 0.0) {
         omx = 0.0;
@@ -3721,7 +3721,7 @@ test "zmath.acos32" {
 
 pub fn modAngle32(in_angle: f32) f32 {
     const angle = in_angle + math.pi;
-    var temp: f32 = @fabs(angle);
+    var temp: f32 = @abs(angle);
     temp = temp - (2.0 * math.pi * @as(f32, @floatFromInt(@as(i32, @intFromFloat(temp / math.pi)))));
     temp = temp - math.pi;
     if (angle < 0.0) {

--- a/src/editor/artboard/flipbook/canvas.zig
+++ b/src/editor/artboard/flipbook/canvas.zig
@@ -99,7 +99,7 @@ pub fn draw(file: *pixi.storage.Internal.Pixi) void {
         const src_x = column * tile_width;
         const src_y = row * tile_height;
 
-        const sprite_scale = std.math.clamp(0.5 / @fabs(@as(f32, @floatFromInt(i)) + (file.flipbook_scroll / tile_width / 1.1)), 0.5, 1.0);
+        const sprite_scale = std.math.clamp(0.5 / @abs(@as(f32, @floatFromInt(i)) + (file.flipbook_scroll / tile_width / 1.1)), 0.5, 1.0);
         const src_rect: [4]f32 = .{ src_x, src_y, tile_width, tile_height };
         var dst_x: f32 = canvas_center_offset[0] + file.flipbook_scroll + @as(f32, @floatFromInt(i)) * tile_width * 1.1 - (tile_width * sprite_scale / 2.0);
         var dst_y: f32 = canvas_center_offset[1] + ((1.0 - sprite_scale) * (tile_height / 2.0));

--- a/src/editor/explorer/tools.zig
+++ b/src/editor/explorer/tools.zig
@@ -59,7 +59,7 @@ pub fn draw() void {
                 pixi.state.colors.height = @as(u8, @intCast(std.math.clamp(height, 0, 255)));
             }
         } else {
-            var primary: [4]f32 = if (pixi.state.tools.current == .heightmap) .{} else .{
+            var primary: [4]f32 = if (pixi.state.tools.current == .heightmap) .{255,255,255,255} else .{
                 @as(f32, @floatFromInt(pixi.state.colors.primary[0])) / 255.0,
                 @as(f32, @floatFromInt(pixi.state.colors.primary[1])) / 255.0,
                 @as(f32, @floatFromInt(pixi.state.colors.primary[2])) / 255.0,

--- a/src/gfx/camera.zig
+++ b/src/gfx/camera.zig
@@ -234,8 +234,8 @@ pub const Camera = struct {
         var nearest_zoom_index: usize = 0;
         var nearest_zoom_step: f32 = pixi.state.settings.zoom_steps[nearest_zoom_index];
         for (pixi.state.settings.zoom_steps, 0..) |step, i| {
-            const step_difference = @fabs(camera.zoom - step);
-            const current_difference = @fabs(camera.zoom - nearest_zoom_step);
+            const step_difference = @abs(camera.zoom - step);
+            const current_difference = @abs(camera.zoom - nearest_zoom_step);
             if (step_difference < current_difference) {
                 nearest_zoom_step = step;
                 nearest_zoom_index = i;
@@ -326,7 +326,7 @@ pub const Camera = struct {
         const i = file.selected_sprite_index;
         const tile_width = @as(f32, @floatFromInt(file.tile_width));
         const tile_height = @as(f32, @floatFromInt(file.tile_height));
-        const sprite_scale = std.math.clamp(0.5 / @fabs(@as(f32, @floatFromInt(i)) + (file.flipbook_scroll / tile_width / 1.1)), 0.5, 1.0);
+        const sprite_scale = std.math.clamp(0.5 / @abs(@as(f32, @floatFromInt(i)) + (file.flipbook_scroll / tile_width / 1.1)), 0.5, 1.0);
         var dst_x: f32 = options.sprite_position[0] + file.flipbook_scroll + @as(f32, @floatFromInt(i)) * tile_width * 1.1 - (tile_width * sprite_scale / 2.0);
         var dst_y: f32 = options.sprite_position[1] + ((1.0 - sprite_scale) * (tile_height / 2.0));
         var dst_width: f32 = tile_width * sprite_scale;

--- a/src/math/direction.zig
+++ b/src/math/direction.zig
@@ -23,8 +23,8 @@ pub const Direction = enum(u8) {
             4 => {
                 var d: u8 = 0;
 
-                const absx = @fabs(vx);
-                const absy = @fabs(vy);
+                const absx = @abs(vx);
+                const absy = @abs(vy);
 
                 if (absy < absx * sqrt2) {
                     //x
@@ -40,8 +40,8 @@ pub const Direction = enum(u8) {
             8 => {
                 var d: u8 = 0;
 
-                const absx = @fabs(vx);
-                const absy = @fabs(vy);
+                const absx = @abs(vx);
+                const absy = @abs(vy);
 
                 if (absy < absx * (sqrt2 + 1.0)) {
                     // x


### PR DESCRIPTION
Hi, after this was merged https://github.com/ziglang/zig/issues/16026 , fabs is no longer builtin and replaced with abs.

this pr fixes that, and another type error from the line below. I'm not actually sure what the previous behavior would have been? but i just changed it to { 255,255,255,255 }. It wouldn't compile with it empty.  
https://github.com/jeremy-coleman/pixi/blob/bdad0113351f461a258c3eeb0fee94b44d507eb2/src/editor/explorer/tools.zig#L62

Anyway, small changes and working with nightly zig installed as-of a couple hours ago.