### PR TITLE
Add 'Pack tileset' option during sprite packing

### DIFF
--- a/src/editor/explorer/pack.zig
+++ b/src/editor/explorer/pack.zig
@@ -54,6 +54,14 @@ pub fn draw() void {
         }
     }
 
+    _ = imgui.checkbox("Pack tileset", &pixi.state.pack_tileset);
+    if (imgui.isItemHovered(imgui.HoveredFlags_DelayNormal)) {
+        if (imgui.beginTooltip()) {
+            defer imgui.endTooltip();
+            imgui.textColored(pixi.state.theme.text_secondary.toImguiVec4(), "Do not tightly pack sprites, pack a uniform grid");
+        }
+    }
+
     {
         var packable: bool = true;
         if (pixi.state.pack_target == .project and pixi.state.project_folder == null) packable = false;

--- a/src/pixi.zig
+++ b/src/pixi.zig
@@ -73,6 +73,7 @@ pub const PixiState = struct {
     open_files: std.ArrayList(storage.Internal.Pixi) = undefined,
     open_references: std.ArrayList(storage.Internal.Reference) = undefined,
     pack_target: PackTarget = .project,
+    pack_tileset: bool = false,
     pack_camera: gfx.Camera = .{},
     packer: Packer = undefined,
     atlas: storage.Internal.Atlas = .{},

--- a/src/tools/Packer.zig
+++ b/src/tools/Packer.zig
@@ -392,6 +392,11 @@ pub fn reduce(texture: *pixi.gfx.Texture, src: [4]usize) ?[4]usize {
     if (width == 0)
         return null;
 
+    // If we are packing a tileset, we want a uniform / non-tightly-packed grid. We remove all
+    // completely empty sprite cells (the return null cases above), but do not trim transparent
+    // regions during packing.
+    if (pixi.state.pack_tileset) return src;
+
     return .{
         left,
         top,


### PR DESCRIPTION
This adds a checkbox under the Packing tab which aims to support packing a texture atlas for _tilesets_ better, particularly for consumption in level editor programs like LDTK.

These programs typically expect a uniform grid of sprites (e.g. 32x32px tiles) where each sprite's size is generally 'fixed', or a multiple of the smallest sprite size (e.g. you might have a 64x64px or 96x96px sprite inside a texture atlas among mostly 32x32px sprites.) - and so expect that e.g. transparency is surrounding sprites' unused space, rather than it being trimmed for more efficient packing as Pixi does today.

With the checkbox unchecked, Pixi exports as it did before:

<img width="1392" alt="image" src="https://github.com/foxnne/pixi/assets/3173176/3af7cbab-df13-46e6-bf4a-3e963b7ec5b5">

With the checkbox checked, Pixi will try to export a sprite atlas that is more compatible with common tileset software like LDTK. Right now this just means it tries to export a uniform grid, not tightly packing sprites:

<img width="1392" alt="image" src="https://github.com/foxnne/pixi/assets/3173176/2fddaa56-edee-44ce-b2bd-f91a05313baa">

In the future, we might need some other options to support this use case better but for now this at least means that if you have a bunch of pixi files representing tilesets, you can export those and get a packed texture with a uniform grid inside it and then consume that in LDTK or other level editor software fairly easily.

Helps foxnne/pixi#46