### PR TITLE
Handle keyframe_palette in deinit

### DIFF
--- a/src/pixi.zig
+++ b/src/pixi.zig
@@ -514,6 +514,7 @@ pub fn deinit(_: *App) void {
     if (state.atlas.diffusemap) |*diffusemap| diffusemap.deinit();
     if (state.atlas.heightmap) |*heightmap| heightmap.deinit();
     if (state.colors.palette) |*palette| palette.deinit();
+    if (state.colors.keyframe_palette) |*keyframe_palette| keyframe_palette.deinit();
 
     if (state.clipboard_image) |*image| image.deinit();
 


### PR DESCRIPTION
This change fixes a memory leak error on exit.
As far as I know, it has no other effects. Changed code builds and runs without errors, and all tests continue to pass (on my machine, at least).

If it does somehow mess things up or I'm otherwise missing something, please let me know.