### PR TITLE
Fixed Zig mach version link in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@
 ## Compilation
 - [Linux] Ensure `gtk+3-devel` or similar is installed (for native file dialogs).
 - Install zig using [zigup](https://github.com/marler8997/zigup) `zigup 0.14.0-dev.2577+271452d22` or manually and add to PATH.
-- Zig version required is latest mach nominated version, find [here.](https://machengine.org/about/nominated-zig/#202450-mach)
+- Zig version required is latest mach nominated version, find [here.]https://machengine.org/docs/nominated-zig/#2024110-mach(https://machengine.org/docs/nominated-zig/#2024110-mach)
 - Clone pixi.
 - Build.
     - ```git clone https://github.com/foxnne/pixi.git```


### PR DESCRIPTION
The link didn't quite work just right, and hasn't been updated since the mach version changed.